### PR TITLE
improve walletd sync speed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,8 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ${MINGW_FLAG} ${WARNINGS} ${CXX_WARNINGS} ${ARCH_FLAG} -maes")
     if(APPLE)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGTEST_HAS_TR1_TUPLE=0")
+        #  Disable ld boost warnings
+        set(CMAKE_CXX_VISIBILITY_PRESET hidden)
     endif()
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND NOT (CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8))
         set(DEBUG_FLAGS "-g3 -Og -gdwarf-4 -fvar-tracking -fvar-tracking-assignments -fno-inline -fno-omit-frame-pointer")

--- a/src/PaymentGateService/PaymentGateService.cpp
+++ b/src/PaymentGateService/PaymentGateService.cpp
@@ -24,6 +24,7 @@
 #include "P2p/NetNode.h"
 #include <System/Context.h>
 #include "Wallet/WalletGreen.h"
+#include "CryptoNoteConfig.h"
 
 #ifdef ERROR
 #undef ERROR
@@ -36,6 +37,16 @@
 #endif
 
 using namespace PaymentService;
+
+namespace {
+const uint64_t MEGABYTE = 1024 * 1024;
+const uint64_t WRITE_BUFFER_MB_DEFAULT_SIZE = CryptoNote::DB_WRITE_BUFFER_MB_DEFAULT_SIZE * MEGABYTE;
+const uint64_t READ_BUFFER_MB_DEFAULT_SIZE = CryptoNote::DB_READ_BUFFER_MB_DEFAULT_SIZE * MEGABYTE;
+const uint32_t DEFAULT_MAX_OPEN_FILES = CryptoNote::DB_DEFAULT_MAX_OPEN_FILES;
+const uint16_t DEFAULT_BACKGROUND_THREADS_COUNT = CryptoNote::DB_DEFAULT_BACKGROUND_THREADS_COUNT;
+
+
+} //namespace
 
 void changeDirectory(const std::string& path) {
 #ifdef _WIN32
@@ -154,11 +165,12 @@ void PaymentGateService::runInProcess(Logging::LoggerRef& log) {
   //TODO: make command line options
   dbConfig.setConfigFolderDefaulted(true);
   dbConfig.setDataDir(config.dataDir);
-  dbConfig.setMaxOpenFiles(100);
-  dbConfig.setReadCacheSize(128*1024*1024);
-  dbConfig.setWriteBufferSize(128*1024*1024);
+  dbConfig.setMaxOpenFiles(DEFAULT_MAX_OPEN_FILES);
+
+  dbConfig.setReadCacheSize(READ_BUFFER_MB_DEFAULT_SIZE);
+  dbConfig.setWriteBufferSize(WRITE_BUFFER_MB_DEFAULT_SIZE);
   dbConfig.setTestnet(false);
-  dbConfig.setBackgroundThreadsCount(4);
+  dbConfig.setBackgroundThreadsCount(DEFAULT_BACKGROUND_THREADS_COUNT);
 
   if (dbConfig.isConfigFolderDefaulted()) {
     if (!Tools::create_directories_if_necessary(dbConfig.getDataDir())) {


### PR DESCRIPTION
iridium_walletd now use the global db config (read & write buffers, threads and max open files).
Disable Clang ld boost warning on macosx